### PR TITLE
Refactor: Simplify on_vanity_update to improve performance

### DIFF
--- a/main.py
+++ b/main.py
@@ -148,31 +148,8 @@ async def on_command_completion(context) -> None:
 
 @client.listen("on_guild_update")
 async def on_vanity_update(before, after):
-    with open("jsons/vanity.json", "r") as f:
-        data = json.load(f)
     if before.vanity_url_code != after.vanity_url_code:
-        await asyncio.gather(*[
-            asyncio.gather(*[
-                asyncio.gather(*[
-                    asyncio.gather(*[
-                        asyncio.gather(*[
-                            asyncio.gather(*[
-                                asyncio.gather(*[
-                                    asyncio.gather(*[
-                                        asyncio.gather(*[
-                                            asyncio.gather(*[
-                                                asyncio.gather(
-                                                    *[asyncio.gather(*[protect_vanity(before.id)])])
-                                            ])
-                                        ])
-                                    ])
-                                ])
-                            ])
-                        ])
-                    ])
-                ])
-            ])
-        ])
+        await protect_vanity(before.id)
     else:
         return
 


### PR DESCRIPTION
Removed a dozen unnecessary nested `asyncio.gather` calls that were wrapping a single asynchronous operation in the `on_vanity_update` function. This change significantly improves the performance and readability of the code without altering its functionality.

Also removed an unused variable that was loading data from a JSON file within the same function.

## Summary by Sourcery

Simplify the on_vanity_update handler by removing unnecessary nested asyncio.gather calls and an unused JSON load, directly awaiting the protect_vanity function to improve performance and readability.

Enhancements:
- Replace deeply nested asyncio.gather calls with a single direct await of protect_vanity
- Remove unused variable loading data from jsons/vanity.json